### PR TITLE
Comment out TypeORM configuration in app module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,7 +3,18 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 
 @Module({
-  imports: [],
+  imports: [
+    // TypeOrmModule.forRoot({
+    //   type: 'mysql',
+    //   host: 'localhost',
+    //   port: 3306,
+    //   username: 'root',
+    //   password: 'Masdfg@12345',
+    //   database: 'your_db_name',
+    //   entities: [],
+    //   synchronize: true,
+    // }),
+  ],
   controllers: [AppController],
   providers: [AppService],
 })


### PR DESCRIPTION
The commented-out TypeORM configuration was added but not enabled. This prepares the module for future database integration while ensuring it doesn't interfere with the current setup.